### PR TITLE
Fix for double tab openning after log-out

### DIFF
--- a/content/main.js
+++ b/content/main.js
@@ -135,12 +135,7 @@ var pktUI = (function() {
             openTabWithUrl('https://' + site + '/firefox_learnmore?src=ff_ext&s=ffi&t=buttonclick', true);
 
             // force the panel closed before it opens
-            // wrapped in setTimeout to avoid race condition after logging out
-            // if this test goes to 100%, we should move this logic up before
-            // the panel is actually opened
-            setTimeout(function() {
-                getPanel().hidePopup();
-            }, 0);
+			getPanel().hidePopup();
 
             return;
         }
@@ -332,7 +327,10 @@ var pktUI = (function() {
      * Called when the signup and saved panel was hidden
      */
     function panelDidHide() {
-
+		
+		// clear the onShow and onHide values
+        delete _currentPanelDidShow;
+        delete _currentPanelDidHide;
     }
 
     /**


### PR DESCRIPTION
Primary change: Reset the didShow and didHide events from the panel after it's hidden

The following issue was discovered when the ab test for "tab" is set.
1) User is logged in
2) User logs out
3) User clicks the Pocket button
4) Two copies of the Sign-Up Tab open

What was happening in the code was the following:
1) In Pocket.jsm we called tryToSaveCurrentPage
2) tryToSaveCurrentPage opened the tab and then immediately called hidePopup, canceling the panel open
3) Back up in Pocket.jsm, a few lines later we called window.pktUI.pocketPanelDidShow(); which called the onShow method of the panel that we just closed. This method then tried to make a network call to save the current page, which fails because the user is not logged in and thus attempts to show the sign-up screen again.

When the panel is hidden, we should remove the onShow and onHide events because the panel at that point is considered invalid (if opened again, we reset the onShow and onHide events to what we want them to be).

The reason this was so spotty to reproduce was that because the second tab was due to a failed network call, so timing depended on the user's connection.