### PR TITLE
Expanding Test Variants in Pocket Panel Signups

### DIFF
--- a/content/main.js
+++ b/content/main.js
@@ -146,7 +146,7 @@ var pktUI = (function() {
             var fxasignedin = (typeof userdata == 'object' && userdata !== null) ? '1' : '0';
             var startheight = 490;
             var inOverflowMenu = isInOverflowMenu();
-            var controlvariant = pktApi.getSignupPanelTabTestVariant() == 'control'
+            var controlvariant = pktApi.getSignupPanelTabTestVariant() == 'control';
 
             if (inOverflowMenu)
             {
@@ -161,7 +161,7 @@ var pktUI = (function() {
                 }
             }
             if (!controlvariant) {
-                startheight = 427
+                startheight = 427;
             }
             var variant;
             if (inOverflowMenu)

--- a/content/main.js
+++ b/content/main.js
@@ -132,7 +132,7 @@ var pktUI = (function() {
         if (pktApi.getSignupPanelTabTestVariant() == 'tab')
         {
             let site = Services.prefs.getCharPref("extensions.pocket.site");
-            openTabWithUrl('https://' + site + '/firefox_learnmore?s=ffi&t=autoredirect&tv=page_learnmore&src=ff_ext&s=ffi', true);
+            openTabWithUrl('https://' + site + '/firefox_learnmore?s=ffi&t=autoredirect&tv=page_learnmore&src=ff_ext', true);
 
             // force the panel closed before it opens
             getPanel().hidePopup();
@@ -146,7 +146,7 @@ var pktUI = (function() {
             var fxasignedin = (typeof userdata == 'object' && userdata !== null) ? '1' : '0';
             var startheight = 490;
             var inOverflowMenu = isInOverflowMenu();
-            var controlvariant = (pktApi.getSignupPanelTabTestVariant() == 'control')
+            var controlvariant = pktApi.getSignupPanelTabTestVariant() == 'control'
 
             if (inOverflowMenu)
             {
@@ -160,8 +160,8 @@ var pktUI = (function() {
                     startheight = 406;
                 }
             }
-            if(!controlvariant){
-                startheight=427
+            if (!controlvariant) {
+                startheight = 427
             }
             var variant;
             if (inOverflowMenu)
@@ -173,7 +173,18 @@ var pktUI = (function() {
                 variant = 'storyboard_lm';
             }
 
-            var panelId = showPanel("about:pocket-signup?pockethost=" + Services.prefs.getCharPref("extensions.pocket.site") + "&fxasignedin=" + fxasignedin + "&variant=" + variant + '&controlvariant='+ controlvariant + '&inoverflowmenu=' + inOverflowMenu + "&locale=" + getUILocale(), {
+            var panelId = showPanel("about:pocket-signup?pockethost="
+                + Services.prefs.getCharPref("extensions.pocket.site")
+                + "&fxasignedin="
+                + fxasignedin
+                + "&variant="
+                + variant
+                + '&controlvariant='
+                + controlvariant
+                + '&inoverflowmenu='
+                + inOverflowMenu
+                + "&locale="
+                + getUILocale(), {
                     onShow: function() {
                     },
                     onHide: panelDidHide,

--- a/content/main.js
+++ b/content/main.js
@@ -484,7 +484,11 @@ var pktUI = (function() {
             var e = bundle.getSimpleEnumeration();
             while (e.hasMoreElements()) {
                 var str = e.getNext().QueryInterface(Components.interfaces.nsIPropertyElement);
-                strings[str.key] = str.value;
+                if (str.key in data) {
+                    strings[str.key] = bundle.formatStringFromName(str.key, data[str.key], data[str.key].length);
+                } else {
+                    strings[str.key] = str.value;
+                }
             }
             pktUIMessaging.sendResponseMessageToPanel(panelId, _initL10NMessageId, { strings: strings });
         });

--- a/content/main.js
+++ b/content/main.js
@@ -132,7 +132,7 @@ var pktUI = (function() {
         if (pktApi.getSignupPanelTabTestVariant() == 'tab')
         {
             let site = Services.prefs.getCharPref("extensions.pocket.site");
-            openTabWithUrl('https://' + site + '/firefox_learnmore?src=ff_ext&s=ffi&t=buttonclick', true);
+            openTabWithUrl('https://' + site + '/firefox_learnmore?s=ffi&t=autoredirect&tv=page_learnmore&src=ff_ext&s=ffi', true);
 
             // force the panel closed before it opens
             getPanel().hidePopup();
@@ -146,6 +146,7 @@ var pktUI = (function() {
             var fxasignedin = (typeof userdata == 'object' && userdata !== null) ? '1' : '0';
             var startheight = 490;
             var inOverflowMenu = isInOverflowMenu();
+            var controlvariant = (pktApi.getSignupPanelTabTestVariant() == 'control')
 
             if (inOverflowMenu)
             {
@@ -159,6 +160,9 @@ var pktUI = (function() {
                     startheight = 406;
                 }
             }
+            if(!controlvariant){
+                startheight=427
+            }
             var variant;
             if (inOverflowMenu)
             {
@@ -169,7 +173,7 @@ var pktUI = (function() {
                 variant = 'storyboard_lm';
             }
 
-            var panelId = showPanel("about:pocket-signup?pockethost=" + Services.prefs.getCharPref("extensions.pocket.site") + "&fxasignedin=" + fxasignedin + "&variant=" + variant + '&inoverflowmenu=' + inOverflowMenu + "&locale=" + getUILocale(), {
+            var panelId = showPanel("about:pocket-signup?pockethost=" + Services.prefs.getCharPref("extensions.pocket.site") + "&fxasignedin=" + fxasignedin + "&variant=" + variant + '&controlvariant='+ controlvariant + '&inoverflowmenu=' + inOverflowMenu + "&locale=" + getUILocale(), {
                     onShow: function() {
                     },
                     onHide: panelDidHide,

--- a/content/panels/css/signup.css
+++ b/content/panels/css/signup.css
@@ -32,8 +32,8 @@
 }
 .pkt_ext_cf:after {
     content: " ";
-    display:table;
-    clear:both;
+    display: table;
+    clear: both;
 }
 @keyframes pkt_ext_hide {
     0% {
@@ -145,11 +145,11 @@
     margin-top: 22px;
 }
 .pkt_ext_signupdetail p.pkt_ext_tos{
-    color:#777;
+    color: #777;
     font-size: 10px;
-    line-height:1.5;
+    line-height: 1.5;
     margin-top: 17px;
-    padding-top:0;
+    padding-top: 0;
     max-width: 190px;
 }
 
@@ -291,7 +291,7 @@
     padding: 0;
 }
 .pkt_ext_containersignup .signup-btn-tryitnow{
-    margin-top:25px;
+    margin-top: 25px;
 }
 .pkt_ext_containersignup .signup-btn-firefox .logo {
     background: url(../img/signup_firefoxlogo@1x.png) center center no-repeat;

--- a/content/panels/css/signup.css
+++ b/content/panels/css/signup.css
@@ -60,7 +60,7 @@
     margin: 0 auto 1.5em;
     max-width: 260px;
 }
-.pkt_ext_containersignup a { 
+.pkt_ext_containersignup a {
     color: #4c8fd0;
 }
 .pkt_ext_containersignup a:hover {
@@ -140,6 +140,17 @@
     font-size: 12px;
     max-width: 320px;
     margin-top: 15px;
+}
+.pkt_ext_containersignup .tryitnowspace {
+    margin-top: 22px;
+}
+.pkt_ext_signupdetail p.pkt_ext_tos{
+    color:#777;
+    font-size: 10px;
+    line-height:1.5;
+    margin-top: 17px;
+    padding-top:0;
+    max-width: 190px;
 }
 
 /*=Core detail - storyboard
@@ -259,6 +270,7 @@
     opacity: 0.9;
 }
 .pkt_ext_containersignup .signup-btn-firefox,
+.pkt_ext_containersignup .signup-btn-tryitnow,
 .pkt_ext_containersignup .signup-btn-email,
 .pkt_ext_containersignup .signupinterim-btn-login,
 .pkt_ext_containersignup .signupinterim-btn-signup,
@@ -272,10 +284,14 @@
     position: relative;
     z-index: 10;
 }
+.pkt_ext_containersignup .signup-btn-tryitnow,
 .pkt_ext_containersignup .signup-btn-firefox {
     min-width: 14.5em;
     position: relative;
     padding: 0;
+}
+.pkt_ext_containersignup .signup-btn-tryitnow{
+    margin-top:25px;
 }
 .pkt_ext_containersignup .signup-btn-firefox .logo {
     background: url(../img/signup_firefoxlogo@1x.png) center center no-repeat;
@@ -295,6 +311,7 @@
 .pkt_ext_containersignup .forgotreset-btn-change {
     margin-bottom: 2em;
 }
+.pkt_ext_containersignup .signup-btn-tryitnow .text,
 .pkt_ext_containersignup .signup-btn-firefox .text {
     display: inline-block;
     padding: 0.8em 1.625em;
@@ -302,6 +319,7 @@
     text-shadow: none;
     white-space: nowrap;
 }
+.pkt_ext_containersignup .signup-btn-tryitnow .text,
 .pkt_ext_containersignup .signup-btn-firefox .text {
     color: #fff;
 }
@@ -322,12 +340,14 @@
     width: 200px;
 }
 .pkt_ext_signup_overflow .signup-btn-firefox,
+.pkt_ext_containersignup .signup-btn-tryitnow,
 .pkt_ext_signup_overflow .signup-btn-email {
     font-size: 14px;
     min-width: 12.6em;
     padding-left: 0.75em;
     padding-right: 0.75em;
 }
+.pkt_ext_signup_overflow .signup-btn-tryitnow .text,
 .pkt_ext_signup_overflow .signup-btn-firefox .text {
     padding-left: 0;
     padding-right: 0;
@@ -346,17 +366,22 @@
     margin-bottom: 0.5em;
 }
 .pkt_ext_signup_de .signup-btn-firefox .text,
+.pkt_ext_signup_de .signup-btn-tryitnow .text,
 .pkt_ext_signup_de .signup-btn-email,
 .pkt_ext_signup_es .pkt_ext_signupdetail_hero .signup-btn-firefox .text,
 .pkt_ext_signup_es .pkt_ext_signupdetail_hero .signup-btn-email,
 .pkt_ext_signup_ja .signup-btn-firefox .text,
+.pkt_ext_signup_ja .signup-btn-tryitnow .text,
 .pkt_ext_signup_ja .signup-btn-email,
 .pkt_ext_signup_ru .signup-btn-firefox .text,
+.pkt_ext_signup_ru .signup-btn-tryitnow .text,
 .pkt_ext_signup_ru .signup-btn-email {
     font-size: 15px;
 }
 .pkt_ext_signup_ja .signup-btn-firefox .text,
-.pkt_ext_signup_ru .signup-btn-firefox .text {
+.pkt_ext_signup_ja .signup-btn-tryitnow .text,
+.pkt_ext_signup_ru .signup-btn-firefox .text
+.pkt_ext_signup_ru .signup-btn-tryitnow .text, {
     left: 15px;
 }
 .pkt_ext_signup_de .signup-btn-firefox .logo,

--- a/content/panels/js/signup.js
+++ b/content/panels/js/signup.js
@@ -55,23 +55,23 @@ var PKT_SIGNUP_OVERLAY = function (options)
     };
     this.getTranslations = function() {
         this.dictJSON = this.setLinks(window.pocketStrings, {
-            tos: [
-                'https://'+ this.pockethost +'/tos?s=ffi&t=tos&tv=panel_tryit',
-                'https://'+ this.pockethost +'/privacy?s=ffi&t=privacypolicy&tv=panel_tryit',
-            ]
+            tos: {
+                tos_link: 'https://'+ this.pockethost +'/tos?s=ffi&t=tos&tv=panel_tryit',
+                privacy_link: 'https://'+ this.pockethost +'/privacy?s=ffi&t=privacypolicy&tv=panel_tryit'
+            }
         });
     };
-    this.setLinks = function(stringObject, replaceObject) {
-        var re = /\*/i;
+    this.setLinks = function(stringObject, replaceObject){
         for (var prop in replaceObject) {
-            for (var i = 0; i < replaceObject[prop].length; i++) {
-                if(stringObject[prop]){
-                    stringObject[prop] = stringObject[prop].replace(re, replaceObject[prop][i])
+            if(stringObject[prop]) {
+                for (var key in replaceObject[prop]) {
+                    var regex = new RegExp('(\\[' + key + '\\])', 'i');
+                    stringObject[prop] = stringObject[prop].replace(regex, replaceObject[prop][key]);
                 }
             }
         }
-        return stringObject
-    }
+        return stringObject;
+    };
 
 };
 

--- a/content/panels/js/signup.js
+++ b/content/panels/js/signup.js
@@ -56,8 +56,8 @@ var PKT_SIGNUP_OVERLAY = function (options)
     this.getTranslations = function() {
         this.dictJSON = this.setLinks(window.pocketStrings, {
             tos: [
-                'https://getpocket.com/tos?s=ffi&t=tos&tv=panel_tryit',
-                'https://getpocket.com/privacy?s=ffi&t=privacypolicy&tv=panel_tryit',
+                'https://'+ this.pockethost +'/tos?s=ffi&t=tos&tv=panel_tryit',
+                'https://'+ this.pockethost +'/privacy?s=ffi&t=privacypolicy&tv=panel_tryit',
             ]
         });
     };

--- a/content/panels/js/signup.js
+++ b/content/panels/js/signup.js
@@ -53,24 +53,9 @@ var PKT_SIGNUP_OVERLAY = function (options)
             return sanitizeMap[str];
         });
     };
-    this.getTranslations = function() {
-        this.dictJSON = this.setLinks(window.pocketStrings, {
-            tos: {
-                tos_link: 'https://'+ this.pockethost +'/tos?s=ffi&t=tos&tv=panel_tryit',
-                privacy_link: 'https://'+ this.pockethost +'/privacy?s=ffi&t=privacypolicy&tv=panel_tryit'
-            }
-        });
-    };
-    this.setLinks = function(stringObject, replaceObject){
-        for (var prop in replaceObject) {
-            if(stringObject[prop]) {
-                for (var key in replaceObject[prop]) {
-                    var regex = new RegExp('(\\[' + key + '\\])', 'i');
-                    stringObject[prop] = stringObject[prop].replace(regex, replaceObject[prop][key]);
-                }
-            }
-        }
-        return stringObject;
+    this.getTranslations = function()
+    {
+        this.dictJSON = window.pocketStrings;
     };
 
 };
@@ -196,8 +181,14 @@ $(function()
         thePKT_SIGNUP.init();
     }
 
+    var pocketHost = thePKT_SIGNUP.overlay.pockethost;
     // send an async message to get string data
-    thePKT_SIGNUP.sendMessage("initL10N", {}, function(resp) {
+    thePKT_SIGNUP.sendMessage("initL10N", {
+            tos: [
+                'https://'+ pocketHost +'/tos?s=ffi&t=tos&tv=panel_tryit',
+                'https://'+ pocketHost +'/privacy?s=ffi&t=privacypolicy&tv=panel_tryit'
+            ]
+        }, function(resp) {
         window.pocketStrings = resp.strings;
         window.thePKT_SIGNUP.create();
     });

--- a/content/panels/js/signup.js
+++ b/content/panels/js/signup.js
@@ -18,6 +18,7 @@ var PKT_SIGNUP_OVERLAY = function (options)
     this.autocloseTimer = null;
     this.variant = "";
     this.inoverflowmenu = false;
+    this.controlvariant;
     this.pockethost = "getpocket.com";
     this.fxasignedin = false;
     this.dictJSON = {};
@@ -52,10 +53,26 @@ var PKT_SIGNUP_OVERLAY = function (options)
             return sanitizeMap[str];
         });
     };
-    this.getTranslations = function()
-    {
-        this.dictJSON = window.pocketStrings;
+    this.getTranslations = function() {
+        this.dictJSON = this.setLinks(window.pocketStrings, {
+            tos: [
+                'https://getpocket.com/tos?s=ffi&t=tos&tv=panel_tryit',
+                'https://getpocket.com/privacy?s=ffi&t=privacypolicy&tv=panel_tryit',
+            ]
+        });
     };
+    this.setLinks = function(stringObject, replaceObject) {
+        var re = /\*/i;
+        for (var prop in replaceObject) {
+            for (var i = 0; i < replaceObject[prop].length; i++) {
+                if(stringObject[prop]){
+                    stringObject[prop] = stringObject[prop].replace(re, replaceObject[prop][i])
+                }
+            }
+        }
+        return stringObject
+    }
+
 };
 
 PKT_SIGNUP_OVERLAY.prototype = {
@@ -63,6 +80,11 @@ PKT_SIGNUP_OVERLAY.prototype = {
     {
         var myself = this;
 
+        var controlvariant = window.location.href.match(/controlvariant=([\w|\.]*)&?/);
+        if (controlvariant && controlvariant.length > 1)
+        {
+            this.controlvariant = controlvariant[1];
+        }
         var variant = window.location.href.match(/variant=([\w|\.]*)&?/);
         if (variant && variant.length > 1)
         {
@@ -98,6 +120,7 @@ PKT_SIGNUP_OVERLAY.prototype = {
         // set translations
         this.getTranslations();
         this.dictJSON.fxasignedin = this.fxasignedin ? 1 : 0;
+        this.dictJSON.controlvariant = this.controlvariant == 'true' ? 1 : 0;
         this.dictJSON.variant = (this.variant ? this.variant : 'undefined');
         this.dictJSON.variant += this.fxasignedin ? '_fxa' : '_nonfxa';
         this.dictJSON.pockethost = this.pockethost;

--- a/content/panels/js/tmpl.js
+++ b/content/panels/js/tmpl.js
@@ -1,150 +1,242 @@
 (function() {
   var template = Handlebars.template, templates = Handlebars.templates = Handlebars.templates || {};
-templates['saved_premiumextras'] = template({"compiler":[6, ">= 2.0.0-beta.1"], "main":function(depth0, helpers, partials, data) {
-  return "<div class=\"pkt_ext_suggestedtag_detailshown\">\n</div>";
-  }, "useData":true});
-templates['saved_premiumshell'] = template({"compiler":[6, ">= 2.0.0-beta.1"], "main":function(depth0, helpers, partials, data) {
+templates['saved_premiumextras'] = template({"compiler":[6,">= 2.0.0-beta.1"],"main":function(depth0,helpers,partials,data) {
+  return "<div class=\"pkt_ext_suggestedtag_detailshown\">\r\n</div> ";
+  },"useData":true});
+templates['saved_premiumshell'] = template({"compiler":[6,">= 2.0.0-beta.1"],"main":function(depth0,helpers,partials,data) {
   var helper, functionType="function", helperMissing=helpers.helperMissing, escapeExpression=this.escapeExpression;
   return "<div class=\"pkt_ext_suggestedtag_detail pkt_ext_suggestedtag_detail_loading\">\n    <h4>"
-    + escapeExpression(((helper = (helper = helpers.suggestedtags || (depth0 != null ? depth0.suggestedtags : depth0)) != null ? helper : helperMissing), (typeof helper === functionType ? helper.call(depth0, {"name":"suggestedtags", "hash":{}, "data":data}) : helper)))
+    + escapeExpression(((helper = (helper = helpers.suggestedtags || (depth0 != null ? depth0.suggestedtags : depth0)) != null ? helper : helperMissing),(typeof helper === functionType ? helper.call(depth0, {"name":"suggestedtags","hash":{},"data":data}) : helper)))
     + "</h4>\n    <div class=\"pkt_ext_loadingspinner\"><div></div></div>\n    <ul class=\"pkt_ext_cf\">\n    </ul>\n</div>";
-}, "useData":true});
-templates['saved_shell'] = template({"compiler":[6, ">= 2.0.0-beta.1"], "main":function(depth0, helpers, partials, data) {
+},"useData":true});
+templates['saved_shell'] = template({"compiler":[6,">= 2.0.0-beta.1"],"main":function(depth0,helpers,partials,data) {
   var helper, functionType="function", helperMissing=helpers.helperMissing, escapeExpression=this.escapeExpression;
   return "<div class=\"pkt_ext_initload\">\n    <div class=\"pkt_ext_logo\"></div> \n    <div class=\"pkt_ext_topdetail\">\n        <h2>"
-    + escapeExpression(((helper = (helper = helpers.saving || (depth0 != null ? depth0.saving : depth0)) != null ? helper : helperMissing), (typeof helper === functionType ? helper.call(depth0, {"name":"saving", "hash":{}, "data":data}) : helper)))
-    + "</h2>\n    </div>                     \n    <div class=\"pkt_ext_loadingspinner\"><div></div></div>\n</div>                                      \n<div class=\"pkt_ext_detail\">                        \n    <div class=\"pkt_ext_logo\"></div>\n    <div class=\"pkt_ext_topdetail\">\n        <h2>"
-    + escapeExpression(((helper = (helper = helpers.pagesaved || (depth0 != null ? depth0.pagesaved : depth0)) != null ? helper : helperMissing), (typeof helper === functionType ? helper.call(depth0, {"name":"pagesaved", "hash":{}, "data":data}) : helper)))
+    + escapeExpression(((helper = (helper = helpers.saving || (depth0 != null ? depth0.saving : depth0)) != null ? helper : helperMissing),(typeof helper === functionType ? helper.call(depth0, {"name":"saving","hash":{},"data":data}) : helper)))
+    + "</h2>\n    </div> \n    <div class=\"pkt_ext_loadingspinner\"><div></div></div>\n</div>                                      \n<div class=\"pkt_ext_detail\">                        \n    <div class=\"pkt_ext_logo\"></div>\n    <div class=\"pkt_ext_topdetail\">\n        <h2>"
+    + escapeExpression(((helper = (helper = helpers.pagesaved || (depth0 != null ? depth0.pagesaved : depth0)) != null ? helper : helperMissing),(typeof helper === functionType ? helper.call(depth0, {"name":"pagesaved","hash":{},"data":data}) : helper)))
     + "</h2>\n        <h3 class=\"pkt_ext_errordetail\"></h3>\n        <nav class=\"pkt_ext_item_actions pkt_ext_cf\">\n            <ul>\n                <li><a class=\"pkt_ext_removeitem\" href=\"#\">"
-    + escapeExpression(((helper = (helper = helpers.removepage || (depth0 != null ? depth0.removepage : depth0)) != null ? helper : helperMissing), (typeof helper === functionType ? helper.call(depth0, {"name":"removepage", "hash":{}, "data":data}) : helper)))
+    + escapeExpression(((helper = (helper = helpers.removepage || (depth0 != null ? depth0.removepage : depth0)) != null ? helper : helperMissing),(typeof helper === functionType ? helper.call(depth0, {"name":"removepage","hash":{},"data":data}) : helper)))
     + "</a></li>\n                <li class=\"pkt_ext_actions_separator\"></li>                                \n                <li><a class=\"pkt_ext_openpocket\" href=\"https://"
-    + escapeExpression(((helper = (helper = helpers.pockethost || (depth0 != null ? depth0.pockethost : depth0)) != null ? helper : helperMissing), (typeof helper === functionType ? helper.call(depth0, {"name":"pockethost", "hash":{}, "data":data}) : helper)))
+    + escapeExpression(((helper = (helper = helpers.pockethost || (depth0 != null ? depth0.pockethost : depth0)) != null ? helper : helperMissing),(typeof helper === functionType ? helper.call(depth0, {"name":"pockethost","hash":{},"data":data}) : helper)))
     + "/a?src=ff_ext_saved\" target=\"_blank\">"
-    + escapeExpression(((helper = (helper = helpers.viewlist || (depth0 != null ? depth0.viewlist : depth0)) != null ? helper : helperMissing), (typeof helper === functionType ? helper.call(depth0, {"name":"viewlist", "hash":{}, "data":data}) : helper)))
+    + escapeExpression(((helper = (helper = helpers.viewlist || (depth0 != null ? depth0.viewlist : depth0)) != null ? helper : helperMissing),(typeof helper === functionType ? helper.call(depth0, {"name":"viewlist","hash":{},"data":data}) : helper)))
     + "</a></li>\n            </ul>\n        </nav>                        \n    </div>\n    <div class=\"pkt_ext_tag_detail pkt_ext_cf\">\n        <div class=\"pkt_ext_tag_input_wrapper\">\n            <div class=\"pkt_ext_tag_input_blocker\"></div>\n            <input class=\"pkt_ext_tag_input\" type=\"text\" placeholder=\""
-    + escapeExpression(((helper = (helper = helpers.addtags || (depth0 != null ? depth0.addtags : depth0)) != null ? helper : helperMissing), (typeof helper === functionType ? helper.call(depth0, {"name":"addtags", "hash":{}, "data":data}) : helper)))
+    + escapeExpression(((helper = (helper = helpers.addtags || (depth0 != null ? depth0.addtags : depth0)) != null ? helper : helperMissing),(typeof helper === functionType ? helper.call(depth0, {"name":"addtags","hash":{},"data":data}) : helper)))
     + "\">\n        </div>\n        <a href=\"#\" class=\"pkt_ext_btn pkt_ext_btn_disabled\">"
-    + escapeExpression(((helper = (helper = helpers.save || (depth0 != null ? depth0.save : depth0)) != null ? helper : helperMissing), (typeof helper === functionType ? helper.call(depth0, {"name":"save", "hash":{}, "data":data}) : helper)))
-    + "</a>\n    </div>\n    <p class=\"pkt_ext_edit_msg\"></p>                        \n</div>";
-}, "useData":true});
-templates['signup_shell'] = template({"1":function(depth0, helpers, partials, data) {
+    + escapeExpression(((helper = (helper = helpers.save || (depth0 != null ? depth0.save : depth0)) != null ? helper : helperMissing),(typeof helper === functionType ? helper.call(depth0, {"name":"save","hash":{},"data":data}) : helper)))
+    + "</a>\n    </div>\n    <p class=\"pkt_ext_edit_msg\"></p>\n</div>";
+},"useData":true});
+templates['signup_shell'] = template({"1":function(depth0,helpers,partials,data) {
+  var stack1, buffer = "";
+  stack1 = helpers['if'].call(depth0, (depth0 != null ? depth0.controlvariant : depth0), {"name":"if","hash":{},"fn":this.program(2, data),"inverse":this.program(4, data),"data":data});
+  if (stack1 != null) { buffer += stack1; }
+  return buffer;
+},"2":function(depth0,helpers,partials,data) {
   var helper, functionType="function", helperMissing=helpers.helperMissing, escapeExpression=this.escapeExpression;
-  return "	<p class=\"pkt_ext_learnmorecontainer\"><a class=\"pkt_ext_learnmore\" href=\"https://"
-    + escapeExpression(((helper = (helper = helpers.pockethost || (depth0 != null ? depth0.pockethost : depth0)) != null ? helper : helperMissing), (typeof helper === functionType ? helper.call(depth0, {"name":"pockethost", "hash":{}, "data":data}) : helper)))
-    + "?s=ffi&t=learnmore&v="
-    + escapeExpression(((helper = (helper = helpers.variant || (depth0 != null ? depth0.variant : depth0)) != null ? helper : helperMissing), (typeof helper === functionType ? helper.call(depth0, {"name":"variant", "hash":{}, "data":data}) : helper)))
+  return "      <p class=\"pkt_ext_learnmorecontainer\"><a class=\"pkt_ext_learnmore\" href=\"https://"
+    + escapeExpression(((helper = (helper = helpers.pockethost || (depth0 != null ? depth0.pockethost : depth0)) != null ? helper : helperMissing),(typeof helper === functionType ? helper.call(depth0, {"name":"pockethost","hash":{},"data":data}) : helper)))
+    + "/firefox_learnmore?s=ffi&t=learnmore&tv=panel_control&v="
+    + escapeExpression(((helper = (helper = helpers.variant || (depth0 != null ? depth0.variant : depth0)) != null ? helper : helperMissing),(typeof helper === functionType ? helper.call(depth0, {"name":"variant","hash":{},"data":data}) : helper)))
     + "\" target=\"_blank\">"
-    + escapeExpression(((helper = (helper = helpers.learnmore || (depth0 != null ? depth0.learnmore : depth0)) != null ? helper : helperMissing), (typeof helper === functionType ? helper.call(depth0, {"name":"learnmore", "hash":{}, "data":data}) : helper)))
+    + escapeExpression(((helper = (helper = helpers.learnmore || (depth0 != null ? depth0.learnmore : depth0)) != null ? helper : helperMissing),(typeof helper === functionType ? helper.call(depth0, {"name":"learnmore","hash":{},"data":data}) : helper)))
     + "</a></p>\n";
-}, "3":function(depth0, helpers, partials, data) {
+},"4":function(depth0,helpers,partials,data) {
   var helper, functionType="function", helperMissing=helpers.helperMissing, escapeExpression=this.escapeExpression;
-  return "	<p class=\"pkt_ext_learnmorecontainer\"><a class=\"pkt_ext_learnmore pkt_ext_learnmoreinactive\" href=\"#\">"
-    + escapeExpression(((helper = (helper = helpers.learnmore || (depth0 != null ? depth0.learnmore : depth0)) != null ? helper : helperMissing), (typeof helper === functionType ? helper.call(depth0, {"name":"learnmore", "hash":{}, "data":data}) : helper)))
+  return "      <p class=\"pkt_ext_learnmorecontainer\"><a class=\"pkt_ext_learnmore\" href=\"https://"
+    + escapeExpression(((helper = (helper = helpers.pockethost || (depth0 != null ? depth0.pockethost : depth0)) != null ? helper : helperMissing),(typeof helper === functionType ? helper.call(depth0, {"name":"pockethost","hash":{},"data":data}) : helper)))
+    + "/firefox_learnmore?s=ffi&t=learnmore&tv=panel_tryit&v="
+    + escapeExpression(((helper = (helper = helpers.variant || (depth0 != null ? depth0.variant : depth0)) != null ? helper : helperMissing),(typeof helper === functionType ? helper.call(depth0, {"name":"variant","hash":{},"data":data}) : helper)))
+    + "\" target=\"_blank\">"
+    + escapeExpression(((helper = (helper = helpers.learnmore || (depth0 != null ? depth0.learnmore : depth0)) != null ? helper : helperMissing),(typeof helper === functionType ? helper.call(depth0, {"name":"learnmore","hash":{},"data":data}) : helper)))
     + "</a></p>\n";
-}, "5":function(depth0, helpers, partials, data) {
+},"6":function(depth0,helpers,partials,data) {
   var helper, functionType="function", helperMissing=helpers.helperMissing, escapeExpression=this.escapeExpression;
-  return "	<p class=\"btn-container\"><a href=\"https://"
-    + escapeExpression(((helper = (helper = helpers.pockethost || (depth0 != null ? depth0.pockethost : depth0)) != null ? helper : helperMissing), (typeof helper === functionType ? helper.call(depth0, {"name":"pockethost", "hash":{}, "data":data}) : helper)))
+  return "  <p class=\"pkt_ext_learnmorecontainer\"><a class=\"pkt_ext_learnmore pkt_ext_learnmoreinactive\" href=\"#\">"
+    + escapeExpression(((helper = (helper = helpers.learnmore || (depth0 != null ? depth0.learnmore : depth0)) != null ? helper : helperMissing),(typeof helper === functionType ? helper.call(depth0, {"name":"learnmore","hash":{},"data":data}) : helper)))
+    + "</a></p>\n";
+},"8":function(depth0,helpers,partials,data) {
+  var helper, functionType="function", helperMissing=helpers.helperMissing, escapeExpression=this.escapeExpression;
+  return "  <h4>"
+    + escapeExpression(((helper = (helper = helpers.signuptosave || (depth0 != null ? depth0.signuptosave : depth0)) != null ? helper : helperMissing),(typeof helper === functionType ? helper.call(depth0, {"name":"signuptosave","hash":{},"data":data}) : helper)))
+    + "</h4>\n  <p class=\"btn-container\"><a href=\"https://"
+    + escapeExpression(((helper = (helper = helpers.pockethost || (depth0 != null ? depth0.pockethost : depth0)) != null ? helper : helperMissing),(typeof helper === functionType ? helper.call(depth0, {"name":"pockethost","hash":{},"data":data}) : helper)))
     + "/ff_signup?s=ffi&t=signupff&v="
-    + escapeExpression(((helper = (helper = helpers.variant || (depth0 != null ? depth0.variant : depth0)) != null ? helper : helperMissing), (typeof helper === functionType ? helper.call(depth0, {"name":"variant", "hash":{}, "data":data}) : helper)))
+    + escapeExpression(((helper = (helper = helpers.variant || (depth0 != null ? depth0.variant : depth0)) != null ? helper : helperMissing),(typeof helper === functionType ? helper.call(depth0, {"name":"variant","hash":{},"data":data}) : helper)))
     + "\" target=\"_blank\" class=\"btn signup-btn-firefox\"><span class=\"logo\"></span><span class=\"text\">"
-    + escapeExpression(((helper = (helper = helpers.signinfirefox || (depth0 != null ? depth0.signinfirefox : depth0)) != null ? helper : helperMissing), (typeof helper === functionType ? helper.call(depth0, {"name":"signinfirefox", "hash":{}, "data":data}) : helper)))
-    + "</span></a></p>\n";
-}, "7":function(depth0, helpers, partials, data) {
-  var helper, functionType="function", helperMissing=helpers.helperMissing, escapeExpression=this.escapeExpression;
-  return "	<p class=\"btn-container\"><a href=\"https://"
-    + escapeExpression(((helper = (helper = helpers.pockethost || (depth0 != null ? depth0.pockethost : depth0)) != null ? helper : helperMissing), (typeof helper === functionType ? helper.call(depth0, {"name":"pockethost", "hash":{}, "data":data}) : helper)))
-    + "/ff_signup?s=ffi&t=signupff&v="
-    + escapeExpression(((helper = (helper = helpers.variant || (depth0 != null ? depth0.variant : depth0)) != null ? helper : helperMissing), (typeof helper === functionType ? helper.call(depth0, {"name":"variant", "hash":{}, "data":data}) : helper)))
-    + "\" target=\"_blank\" class=\"btn signup-btn-firefox\"><span class=\"logo\"></span><span class=\"text\">"
-    + escapeExpression(((helper = (helper = helpers.signupfirefox || (depth0 != null ? depth0.signupfirefox : depth0)) != null ? helper : helperMissing), (typeof helper === functionType ? helper.call(depth0, {"name":"signupfirefox", "hash":{}, "data":data}) : helper)))
-    + "</span></a></p>\n	<p class=\"btn-container\"><a href=\"https://"
-    + escapeExpression(((helper = (helper = helpers.pockethost || (depth0 != null ? depth0.pockethost : depth0)) != null ? helper : helperMissing), (typeof helper === functionType ? helper.call(depth0, {"name":"pockethost", "hash":{}, "data":data}) : helper)))
-    + "/signup?force=email&src=extension&s=ffi&t=signupemail&v="
-    + escapeExpression(((helper = (helper = helpers.variant || (depth0 != null ? depth0.variant : depth0)) != null ? helper : helperMissing), (typeof helper === functionType ? helper.call(depth0, {"name":"variant", "hash":{}, "data":data}) : helper)))
-    + "\" target=\"_blank\" class=\"btn btn-secondary signup-btn-email signup-btn-initstate\">"
-    + escapeExpression(((helper = (helper = helpers.signupemail || (depth0 != null ? depth0.signupemail : depth0)) != null ? helper : helperMissing), (typeof helper === functionType ? helper.call(depth0, {"name":"signupemail", "hash":{}, "data":data}) : helper)))
-    + "</a></p>\n";
-}, "compiler":[6, ">= 2.0.0-beta.1"], "main":function(depth0, helpers, partials, data) {
-  var stack1, helper, functionType="function", helperMissing=helpers.helperMissing, escapeExpression=this.escapeExpression, buffer = "<div class=\"pkt_ext_introdetail pkt_ext_introdetailhero\">\n	<h2 class=\"pkt_ext_logo\">Pocket</h2>\n	<p class=\"pkt_ext_tagline\">"
-    + escapeExpression(((helper = (helper = helpers.tagline || (depth0 != null ? depth0.tagline : depth0)) != null ? helper : helperMissing), (typeof helper === functionType ? helper.call(depth0, {"name":"tagline", "hash":{}, "data":data}) : helper)))
-    + "</p>\n";
-  stack1 = helpers['if'].call(depth0, (depth0 != null ? depth0.showlearnmore : depth0), {"name":"if", "hash":{}, "fn":this.program(1, data), "inverse":this.program(3, data), "data":data});
-  if (stack1 != null) { buffer += stack1; }
-  buffer += "	<div class=\"pkt_ext_introimg\"></div>\n</div>\n<div class=\"pkt_ext_signupdetail pkt_ext_signupdetail_hero\">\n	<h4>"
-    + escapeExpression(((helper = (helper = helpers.signuptosave || (depth0 != null ? depth0.signuptosave : depth0)) != null ? helper : helperMissing), (typeof helper === functionType ? helper.call(depth0, {"name":"signuptosave", "hash":{}, "data":data}) : helper)))
-    + "</h4>\n";
-  stack1 = helpers['if'].call(depth0, (depth0 != null ? depth0.fxasignedin : depth0), {"name":"if", "hash":{}, "fn":this.program(5, data), "inverse":this.program(7, data), "data":data});
-  if (stack1 != null) { buffer += stack1; }
-  return buffer + "	<p class=\"alreadyhave\">"
-    + escapeExpression(((helper = (helper = helpers.alreadyhaveacct || (depth0 != null ? depth0.alreadyhaveacct : depth0)) != null ? helper : helperMissing), (typeof helper === functionType ? helper.call(depth0, {"name":"alreadyhaveacct", "hash":{}, "data":data}) : helper)))
+    + escapeExpression(((helper = (helper = helpers.signinfirefox || (depth0 != null ? depth0.signinfirefox : depth0)) != null ? helper : helperMissing),(typeof helper === functionType ? helper.call(depth0, {"name":"signinfirefox","hash":{},"data":data}) : helper)))
+    + "</span></a></p>\n  <p class=\"alreadyhave\">"
+    + escapeExpression(((helper = (helper = helpers.alreadyhaveacct || (depth0 != null ? depth0.alreadyhaveacct : depth0)) != null ? helper : helperMissing),(typeof helper === functionType ? helper.call(depth0, {"name":"alreadyhaveacct","hash":{},"data":data}) : helper)))
     + " <a href=\"https://"
-    + escapeExpression(((helper = (helper = helpers.pockethost || (depth0 != null ? depth0.pockethost : depth0)) != null ? helper : helperMissing), (typeof helper === functionType ? helper.call(depth0, {"name":"pockethost", "hash":{}, "data":data}) : helper)))
+    + escapeExpression(((helper = (helper = helpers.pockethost || (depth0 != null ? depth0.pockethost : depth0)) != null ? helper : helperMissing),(typeof helper === functionType ? helper.call(depth0, {"name":"pockethost","hash":{},"data":data}) : helper)))
     + "/login?ep=3&src=extension&s=ffi&t=login&v="
-    + escapeExpression(((helper = (helper = helpers.variant || (depth0 != null ? depth0.variant : depth0)) != null ? helper : helperMissing), (typeof helper === functionType ? helper.call(depth0, {"name":"variant", "hash":{}, "data":data}) : helper)))
+    + escapeExpression(((helper = (helper = helpers.variant || (depth0 != null ? depth0.variant : depth0)) != null ? helper : helperMissing),(typeof helper === functionType ? helper.call(depth0, {"name":"variant","hash":{},"data":data}) : helper)))
     + "\" target=\"_blank\">"
-    + escapeExpression(((helper = (helper = helpers.loginnow || (depth0 != null ? depth0.loginnow : depth0)) != null ? helper : helperMissing), (typeof helper === functionType ? helper.call(depth0, {"name":"loginnow", "hash":{}, "data":data}) : helper)))
-    + "</a>.</p>\n</div>";
-}, "useData":true});
-templates['signupstoryboard_shell'] = template({"1":function(depth0, helpers, partials, data) {
+    + escapeExpression(((helper = (helper = helpers.loginnow || (depth0 != null ? depth0.loginnow : depth0)) != null ? helper : helperMissing),(typeof helper === functionType ? helper.call(depth0, {"name":"loginnow","hash":{},"data":data}) : helper)))
+    + "</a>.</p>\n";
+},"10":function(depth0,helpers,partials,data) {
+  var stack1, buffer = "";
+  stack1 = helpers['if'].call(depth0, (depth0 != null ? depth0.controlvariant : depth0), {"name":"if","hash":{},"fn":this.program(11, data),"inverse":this.program(13, data),"data":data});
+  if (stack1 != null) { buffer += stack1; }
+  return buffer;
+},"11":function(depth0,helpers,partials,data) {
   var helper, functionType="function", helperMissing=helpers.helperMissing, escapeExpression=this.escapeExpression;
-  return "			<p><a class=\"pkt_ext_learnmore\" href=\"https://"
-    + escapeExpression(((helper = (helper = helpers.pockethost || (depth0 != null ? depth0.pockethost : depth0)) != null ? helper : helperMissing), (typeof helper === functionType ? helper.call(depth0, {"name":"pockethost", "hash":{}, "data":data}) : helper)))
-    + "?s=ffi&t=learnmore&v="
-    + escapeExpression(((helper = (helper = helpers.variant || (depth0 != null ? depth0.variant : depth0)) != null ? helper : helperMissing), (typeof helper === functionType ? helper.call(depth0, {"name":"variant", "hash":{}, "data":data}) : helper)))
-    + "\" target=\"_blank\">"
-    + escapeExpression(((helper = (helper = helpers.learnmore || (depth0 != null ? depth0.learnmore : depth0)) != null ? helper : helperMissing), (typeof helper === functionType ? helper.call(depth0, {"name":"learnmore", "hash":{}, "data":data}) : helper)))
-    + "</a></p>\n";
-}, "3":function(depth0, helpers, partials, data) {
-  var helper, functionType="function", helperMissing=helpers.helperMissing, escapeExpression=this.escapeExpression;
-  return "			<p><a class=\"pkt_ext_learnmore pkt_ext_learnmoreinactive\" href=\"#\">"
-    + escapeExpression(((helper = (helper = helpers.learnmore || (depth0 != null ? depth0.learnmore : depth0)) != null ? helper : helperMissing), (typeof helper === functionType ? helper.call(depth0, {"name":"learnmore", "hash":{}, "data":data}) : helper)))
-    + "</a></p>\n";
-}, "5":function(depth0, helpers, partials, data) {
-  var helper, functionType="function", helperMissing=helpers.helperMissing, escapeExpression=this.escapeExpression;
-  return "	<p class=\"btn-container\"><a href=\"https://"
-    + escapeExpression(((helper = (helper = helpers.pockethost || (depth0 != null ? depth0.pockethost : depth0)) != null ? helper : helperMissing), (typeof helper === functionType ? helper.call(depth0, {"name":"pockethost", "hash":{}, "data":data}) : helper)))
-    + "/ff_signup?s=ffi&t=signupff&v="
-    + escapeExpression(((helper = (helper = helpers.variant || (depth0 != null ? depth0.variant : depth0)) != null ? helper : helperMissing), (typeof helper === functionType ? helper.call(depth0, {"name":"variant", "hash":{}, "data":data}) : helper)))
+  return "      <h4>"
+    + escapeExpression(((helper = (helper = helpers.signuptosave || (depth0 != null ? depth0.signuptosave : depth0)) != null ? helper : helperMissing),(typeof helper === functionType ? helper.call(depth0, {"name":"signuptosave","hash":{},"data":data}) : helper)))
+    + "</h4>\n      <p class=\"btn-container\"><a href=\"https://"
+    + escapeExpression(((helper = (helper = helpers.pockethost || (depth0 != null ? depth0.pockethost : depth0)) != null ? helper : helperMissing),(typeof helper === functionType ? helper.call(depth0, {"name":"pockethost","hash":{},"data":data}) : helper)))
+    + "/ff_signup?s=ffi&tv=panel_control&t=signupff&v="
+    + escapeExpression(((helper = (helper = helpers.variant || (depth0 != null ? depth0.variant : depth0)) != null ? helper : helperMissing),(typeof helper === functionType ? helper.call(depth0, {"name":"variant","hash":{},"data":data}) : helper)))
     + "\" target=\"_blank\" class=\"btn signup-btn-firefox\"><span class=\"logo\"></span><span class=\"text\">"
-    + escapeExpression(((helper = (helper = helpers.signinfirefox || (depth0 != null ? depth0.signinfirefox : depth0)) != null ? helper : helperMissing), (typeof helper === functionType ? helper.call(depth0, {"name":"signinfirefox", "hash":{}, "data":data}) : helper)))
-    + "</span></a></p>\n";
-}, "7":function(depth0, helpers, partials, data) {
-  var helper, functionType="function", helperMissing=helpers.helperMissing, escapeExpression=this.escapeExpression;
-  return "	<p class=\"btn-container\"><a href=\"https://"
-    + escapeExpression(((helper = (helper = helpers.pockethost || (depth0 != null ? depth0.pockethost : depth0)) != null ? helper : helperMissing), (typeof helper === functionType ? helper.call(depth0, {"name":"pockethost", "hash":{}, "data":data}) : helper)))
-    + "/ff_signup?s=ffi&t=signupff&v="
-    + escapeExpression(((helper = (helper = helpers.variant || (depth0 != null ? depth0.variant : depth0)) != null ? helper : helperMissing), (typeof helper === functionType ? helper.call(depth0, {"name":"variant", "hash":{}, "data":data}) : helper)))
-    + "\" target=\"_blank\" class=\"btn signup-btn-firefox\"><span class=\"logo\"></span><span class=\"text\">"
-    + escapeExpression(((helper = (helper = helpers.signupfirefox || (depth0 != null ? depth0.signupfirefox : depth0)) != null ? helper : helperMissing), (typeof helper === functionType ? helper.call(depth0, {"name":"signupfirefox", "hash":{}, "data":data}) : helper)))
-    + "</span></a></p>\n	<p class=\"btn-container\"><a href=\"https://"
-    + escapeExpression(((helper = (helper = helpers.pockethost || (depth0 != null ? depth0.pockethost : depth0)) != null ? helper : helperMissing), (typeof helper === functionType ? helper.call(depth0, {"name":"pockethost", "hash":{}, "data":data}) : helper)))
-    + "/signup?force=email&src=extension&s=ffi&t=signupemail&v="
-    + escapeExpression(((helper = (helper = helpers.variant || (depth0 != null ? depth0.variant : depth0)) != null ? helper : helperMissing), (typeof helper === functionType ? helper.call(depth0, {"name":"variant", "hash":{}, "data":data}) : helper)))
+    + escapeExpression(((helper = (helper = helpers.signupfirefox || (depth0 != null ? depth0.signupfirefox : depth0)) != null ? helper : helperMissing),(typeof helper === functionType ? helper.call(depth0, {"name":"signupfirefox","hash":{},"data":data}) : helper)))
+    + "</span></a></p>\n      <p class=\"btn-container\"><a href=\"https://"
+    + escapeExpression(((helper = (helper = helpers.pockethost || (depth0 != null ? depth0.pockethost : depth0)) != null ? helper : helperMissing),(typeof helper === functionType ? helper.call(depth0, {"name":"pockethost","hash":{},"data":data}) : helper)))
+    + "/signup?force=email&tv=panel_control&src=extension&s=ffi&t=signupemail&v="
+    + escapeExpression(((helper = (helper = helpers.variant || (depth0 != null ? depth0.variant : depth0)) != null ? helper : helperMissing),(typeof helper === functionType ? helper.call(depth0, {"name":"variant","hash":{},"data":data}) : helper)))
     + "\" target=\"_blank\" class=\"btn btn-secondary signup-btn-email signup-btn-initstate\">"
-    + escapeExpression(((helper = (helper = helpers.signupemail || (depth0 != null ? depth0.signupemail : depth0)) != null ? helper : helperMissing), (typeof helper === functionType ? helper.call(depth0, {"name":"signupemail", "hash":{}, "data":data}) : helper)))
-    + "</a></p>\n";
-}, "compiler":[6, ">= 2.0.0-beta.1"], "main":function(depth0, helpers, partials, data) {
-  var stack1, helper, functionType="function", helperMissing=helpers.helperMissing, escapeExpression=this.escapeExpression, buffer = "<div class=\"pkt_ext_introdetail pkt_ext_introdetailstoryboard\">\n	<div class=\"pkt_ext_introstory pkt_ext_introstoryone\">\n		<div class=\"pkt_ext_introstory_text\">\n			<p class=\"pkt_ext_tagline\">"
-    + escapeExpression(((helper = (helper = helpers.taglinestory_one || (depth0 != null ? depth0.taglinestory_one : depth0)) != null ? helper : helperMissing), (typeof helper === functionType ? helper.call(depth0, {"name":"taglinestory_one", "hash":{}, "data":data}) : helper)))
-    + "</p>\n		</div>\n		<div class=\"pkt_ext_introstoryone_img\"></div>\n	</div>\n	<div class=\"pkt_ext_introstorydivider\"></div>\n	<div class=\"pkt_ext_introstory pkt_ext_introstorytwo\">\n		<div class=\"pkt_ext_introstory_text\">\n			<p class=\"pkt_ext_tagline\">"
-    + escapeExpression(((helper = (helper = helpers.taglinestory_two || (depth0 != null ? depth0.taglinestory_two : depth0)) != null ? helper : helperMissing), (typeof helper === functionType ? helper.call(depth0, {"name":"taglinestory_two", "hash":{}, "data":data}) : helper)))
-    + "</p>\n";
-  stack1 = helpers['if'].call(depth0, (depth0 != null ? depth0.showlearnmore : depth0), {"name":"if", "hash":{}, "fn":this.program(1, data), "inverse":this.program(3, data), "data":data});
-  if (stack1 != null) { buffer += stack1; }
-  buffer += "		</div>\n		<div class=\"pkt_ext_introstorytwo_img\"></div>\n	</div>\n</div>\n<div class=\"pkt_ext_signupdetail\">\n	<h4>"
-    + escapeExpression(((helper = (helper = helpers.signuptosave || (depth0 != null ? depth0.signuptosave : depth0)) != null ? helper : helperMissing), (typeof helper === functionType ? helper.call(depth0, {"name":"signuptosave", "hash":{}, "data":data}) : helper)))
-    + "</h4>\n";
-  stack1 = helpers['if'].call(depth0, (depth0 != null ? depth0.fxasignedin : depth0), {"name":"if", "hash":{}, "fn":this.program(5, data), "inverse":this.program(7, data), "data":data});
-  if (stack1 != null) { buffer += stack1; }
-  return buffer + "	<p class=\"alreadyhave\">"
-    + escapeExpression(((helper = (helper = helpers.alreadyhaveacct || (depth0 != null ? depth0.alreadyhaveacct : depth0)) != null ? helper : helperMissing), (typeof helper === functionType ? helper.call(depth0, {"name":"alreadyhaveacct", "hash":{}, "data":data}) : helper)))
+    + escapeExpression(((helper = (helper = helpers.signupemail || (depth0 != null ? depth0.signupemail : depth0)) != null ? helper : helperMissing),(typeof helper === functionType ? helper.call(depth0, {"name":"signupemail","hash":{},"data":data}) : helper)))
+    + "</a></p>\n     <p class=\"alreadyhave\">"
+    + escapeExpression(((helper = (helper = helpers.alreadyhaveacct || (depth0 != null ? depth0.alreadyhaveacct : depth0)) != null ? helper : helperMissing),(typeof helper === functionType ? helper.call(depth0, {"name":"alreadyhaveacct","hash":{},"data":data}) : helper)))
     + " <a href=\"https://"
-    + escapeExpression(((helper = (helper = helpers.pockethost || (depth0 != null ? depth0.pockethost : depth0)) != null ? helper : helperMissing), (typeof helper === functionType ? helper.call(depth0, {"name":"pockethost", "hash":{}, "data":data}) : helper)))
-    + "/login?ep=3&src=extension&s=ffi&t=login&v="
-    + escapeExpression(((helper = (helper = helpers.variant || (depth0 != null ? depth0.variant : depth0)) != null ? helper : helperMissing), (typeof helper === functionType ? helper.call(depth0, {"name":"variant", "hash":{}, "data":data}) : helper)))
+    + escapeExpression(((helper = (helper = helpers.pockethost || (depth0 != null ? depth0.pockethost : depth0)) != null ? helper : helperMissing),(typeof helper === functionType ? helper.call(depth0, {"name":"pockethost","hash":{},"data":data}) : helper)))
+    + "/login?ep=3&tv=panel_control&src=extension&s=ffi&t=login&v="
+    + escapeExpression(((helper = (helper = helpers.variant || (depth0 != null ? depth0.variant : depth0)) != null ? helper : helperMissing),(typeof helper === functionType ? helper.call(depth0, {"name":"variant","hash":{},"data":data}) : helper)))
     + "\" target=\"_blank\">"
-    + escapeExpression(((helper = (helper = helpers.loginnow || (depth0 != null ? depth0.loginnow : depth0)) != null ? helper : helperMissing), (typeof helper === functionType ? helper.call(depth0, {"name":"loginnow", "hash":{}, "data":data}) : helper)))
-    + "</a>.</p>\n</div>";
-}, "useData":true});
+    + escapeExpression(((helper = (helper = helpers.loginnow || (depth0 != null ? depth0.loginnow : depth0)) != null ? helper : helperMissing),(typeof helper === functionType ? helper.call(depth0, {"name":"loginnow","hash":{},"data":data}) : helper)))
+    + "</a>.</p>\n";
+},"13":function(depth0,helpers,partials,data) {
+  var stack1, helper, functionType="function", helperMissing=helpers.helperMissing, escapeExpression=this.escapeExpression, buffer = "      <p class=\"btn-container\"><a href=\"https://"
+    + escapeExpression(((helper = (helper = helpers.pockethost || (depth0 != null ? depth0.pockethost : depth0)) != null ? helper : helperMissing),(typeof helper === functionType ? helper.call(depth0, {"name":"pockethost","hash":{},"data":data}) : helper)))
+    + "/firefox_tryitnow?s=ffi&tv=panel_tryit&t=tryitnow\" target=\"_blank\" class=\"btn signup-btn-tryitnow\"><span class=\"text\">"
+    + escapeExpression(((helper = (helper = helpers.tryitnow || (depth0 != null ? depth0.tryitnow : depth0)) != null ? helper : helperMissing),(typeof helper === functionType ? helper.call(depth0, {"name":"tryitnow","hash":{},"data":data}) : helper)))
+    + "</span></a></p>\n      <p class=\"alreadyhave tryitnowspace\">"
+    + escapeExpression(((helper = (helper = helpers.alreadyhaveacct || (depth0 != null ? depth0.alreadyhaveacct : depth0)) != null ? helper : helperMissing),(typeof helper === functionType ? helper.call(depth0, {"name":"alreadyhaveacct","hash":{},"data":data}) : helper)))
+    + " <a href=\"https://"
+    + escapeExpression(((helper = (helper = helpers.pockethost || (depth0 != null ? depth0.pockethost : depth0)) != null ? helper : helperMissing),(typeof helper === functionType ? helper.call(depth0, {"name":"pockethost","hash":{},"data":data}) : helper)))
+    + "/login?ep=3&s=ffi&tv=panel_tryit&src=extension&t=login&v="
+    + escapeExpression(((helper = (helper = helpers.variant || (depth0 != null ? depth0.variant : depth0)) != null ? helper : helperMissing),(typeof helper === functionType ? helper.call(depth0, {"name":"variant","hash":{},"data":data}) : helper)))
+    + "\" target=\"_blank\">"
+    + escapeExpression(((helper = (helper = helpers.loginnow || (depth0 != null ? depth0.loginnow : depth0)) != null ? helper : helperMissing),(typeof helper === functionType ? helper.call(depth0, {"name":"loginnow","hash":{},"data":data}) : helper)))
+    + "</a>.</p>\n      <p class=\"pkt_ext_tos\">";
+  stack1 = ((helper = (helper = helpers.tos || (depth0 != null ? depth0.tos : depth0)) != null ? helper : helperMissing),(typeof helper === functionType ? helper.call(depth0, {"name":"tos","hash":{},"data":data}) : helper));
+  if (stack1 != null) { buffer += stack1; }
+  return buffer + "</p>\n";
+},"compiler":[6,">= 2.0.0-beta.1"],"main":function(depth0,helpers,partials,data) {
+  var stack1, helper, functionType="function", helperMissing=helpers.helperMissing, escapeExpression=this.escapeExpression, buffer = "<div class=\"pkt_ext_introdetail pkt_ext_introdetailhero\">\n <h2 class=\"pkt_ext_logo\">Pocket</h2>\n  <p class=\"pkt_ext_tagline\">"
+    + escapeExpression(((helper = (helper = helpers.tagline || (depth0 != null ? depth0.tagline : depth0)) != null ? helper : helperMissing),(typeof helper === functionType ? helper.call(depth0, {"name":"tagline","hash":{},"data":data}) : helper)))
+    + "</p>\n";
+  stack1 = helpers['if'].call(depth0, (depth0 != null ? depth0.showlearnmore : depth0), {"name":"if","hash":{},"fn":this.program(1, data),"inverse":this.program(6, data),"data":data});
+  if (stack1 != null) { buffer += stack1; }
+  buffer += " <div class=\"pkt_ext_introimg\"></div>\n</div>\n<div class=\"pkt_ext_signupdetail pkt_ext_signupdetail_hero\">\n";
+  stack1 = helpers['if'].call(depth0, (depth0 != null ? depth0.fxasignedin : depth0), {"name":"if","hash":{},"fn":this.program(8, data),"inverse":this.program(10, data),"data":data});
+  if (stack1 != null) { buffer += stack1; }
+  return buffer + "</div>\n";
+},"useData":true});
+templates['signupstoryboard_shell'] = template({"1":function(depth0,helpers,partials,data) {
+  var stack1, buffer = "";
+  stack1 = helpers['if'].call(depth0, (depth0 != null ? depth0.controlvariant : depth0), {"name":"if","hash":{},"fn":this.program(2, data),"inverse":this.program(4, data),"data":data});
+  if (stack1 != null) { buffer += stack1; }
+  return buffer;
+},"2":function(depth0,helpers,partials,data) {
+  var helper, functionType="function", helperMissing=helpers.helperMissing, escapeExpression=this.escapeExpression;
+  return "          <p><a class=\"pkt_ext_learnmore\" href=\"https://"
+    + escapeExpression(((helper = (helper = helpers.pockethost || (depth0 != null ? depth0.pockethost : depth0)) != null ? helper : helperMissing),(typeof helper === functionType ? helper.call(depth0, {"name":"pockethost","hash":{},"data":data}) : helper)))
+    + "/firefox_learnmore?s=ffi&t=learnmore&tv=panel_control&v="
+    + escapeExpression(((helper = (helper = helpers.variant || (depth0 != null ? depth0.variant : depth0)) != null ? helper : helperMissing),(typeof helper === functionType ? helper.call(depth0, {"name":"variant","hash":{},"data":data}) : helper)))
+    + "\" target=\"_blank\">"
+    + escapeExpression(((helper = (helper = helpers.learnmore || (depth0 != null ? depth0.learnmore : depth0)) != null ? helper : helperMissing),(typeof helper === functionType ? helper.call(depth0, {"name":"learnmore","hash":{},"data":data}) : helper)))
+    + "</a></p>\n";
+},"4":function(depth0,helpers,partials,data) {
+  var helper, functionType="function", helperMissing=helpers.helperMissing, escapeExpression=this.escapeExpression;
+  return "          <p><a class=\"pkt_ext_learnmore\" href=\"https://"
+    + escapeExpression(((helper = (helper = helpers.pockethost || (depth0 != null ? depth0.pockethost : depth0)) != null ? helper : helperMissing),(typeof helper === functionType ? helper.call(depth0, {"name":"pockethost","hash":{},"data":data}) : helper)))
+    + "/firefox_learnmore?s=ffi&t=learnmore&tv=panel_tryit&v="
+    + escapeExpression(((helper = (helper = helpers.variant || (depth0 != null ? depth0.variant : depth0)) != null ? helper : helperMissing),(typeof helper === functionType ? helper.call(depth0, {"name":"variant","hash":{},"data":data}) : helper)))
+    + "\" target=\"_blank\">"
+    + escapeExpression(((helper = (helper = helpers.learnmore || (depth0 != null ? depth0.learnmore : depth0)) != null ? helper : helperMissing),(typeof helper === functionType ? helper.call(depth0, {"name":"learnmore","hash":{},"data":data}) : helper)))
+    + "</a></p>\n";
+},"6":function(depth0,helpers,partials,data) {
+  var helper, functionType="function", helperMissing=helpers.helperMissing, escapeExpression=this.escapeExpression;
+  return "      <p><a class=\"pkt_ext_learnmore pkt_ext_learnmoreinactive\" href=\"#\">"
+    + escapeExpression(((helper = (helper = helpers.learnmore || (depth0 != null ? depth0.learnmore : depth0)) != null ? helper : helperMissing),(typeof helper === functionType ? helper.call(depth0, {"name":"learnmore","hash":{},"data":data}) : helper)))
+    + "</a></p>\n";
+},"8":function(depth0,helpers,partials,data) {
+  var helper, functionType="function", helperMissing=helpers.helperMissing, escapeExpression=this.escapeExpression;
+  return "  <h4>"
+    + escapeExpression(((helper = (helper = helpers.signuptosave || (depth0 != null ? depth0.signuptosave : depth0)) != null ? helper : helperMissing),(typeof helper === functionType ? helper.call(depth0, {"name":"signuptosave","hash":{},"data":data}) : helper)))
+    + "</h4>\n  <p class=\"btn-container\"><a href=\"https://"
+    + escapeExpression(((helper = (helper = helpers.pockethost || (depth0 != null ? depth0.pockethost : depth0)) != null ? helper : helperMissing),(typeof helper === functionType ? helper.call(depth0, {"name":"pockethost","hash":{},"data":data}) : helper)))
+    + "/ff_signup?s=ffi&t=signupff&v="
+    + escapeExpression(((helper = (helper = helpers.variant || (depth0 != null ? depth0.variant : depth0)) != null ? helper : helperMissing),(typeof helper === functionType ? helper.call(depth0, {"name":"variant","hash":{},"data":data}) : helper)))
+    + "\" target=\"_blank\" class=\"btn signup-btn-firefox\"><span class=\"logo\"></span><span class=\"text\">"
+    + escapeExpression(((helper = (helper = helpers.signinfirefox || (depth0 != null ? depth0.signinfirefox : depth0)) != null ? helper : helperMissing),(typeof helper === functionType ? helper.call(depth0, {"name":"signinfirefox","hash":{},"data":data}) : helper)))
+    + "</span></a></p>\n  <p class=\"alreadyhave\">"
+    + escapeExpression(((helper = (helper = helpers.alreadyhaveacct || (depth0 != null ? depth0.alreadyhaveacct : depth0)) != null ? helper : helperMissing),(typeof helper === functionType ? helper.call(depth0, {"name":"alreadyhaveacct","hash":{},"data":data}) : helper)))
+    + " <a href=\"https://"
+    + escapeExpression(((helper = (helper = helpers.pockethost || (depth0 != null ? depth0.pockethost : depth0)) != null ? helper : helperMissing),(typeof helper === functionType ? helper.call(depth0, {"name":"pockethost","hash":{},"data":data}) : helper)))
+    + "/login?ep=3&src=extension&s=ffi&t=login&v="
+    + escapeExpression(((helper = (helper = helpers.variant || (depth0 != null ? depth0.variant : depth0)) != null ? helper : helperMissing),(typeof helper === functionType ? helper.call(depth0, {"name":"variant","hash":{},"data":data}) : helper)))
+    + "\" target=\"_blank\">"
+    + escapeExpression(((helper = (helper = helpers.loginnow || (depth0 != null ? depth0.loginnow : depth0)) != null ? helper : helperMissing),(typeof helper === functionType ? helper.call(depth0, {"name":"loginnow","hash":{},"data":data}) : helper)))
+    + "</a>.</p>\n";
+},"10":function(depth0,helpers,partials,data) {
+  var stack1, buffer = "";
+  stack1 = helpers['if'].call(depth0, (depth0 != null ? depth0.controlvariant : depth0), {"name":"if","hash":{},"fn":this.program(11, data),"inverse":this.program(13, data),"data":data});
+  if (stack1 != null) { buffer += stack1; }
+  return buffer;
+},"11":function(depth0,helpers,partials,data) {
+  var helper, functionType="function", helperMissing=helpers.helperMissing, escapeExpression=this.escapeExpression;
+  return "      <h4>"
+    + escapeExpression(((helper = (helper = helpers.signuptosave || (depth0 != null ? depth0.signuptosave : depth0)) != null ? helper : helperMissing),(typeof helper === functionType ? helper.call(depth0, {"name":"signuptosave","hash":{},"data":data}) : helper)))
+    + "</h4>\n      <p class=\"btn-container\"><a href=\"https://"
+    + escapeExpression(((helper = (helper = helpers.pockethost || (depth0 != null ? depth0.pockethost : depth0)) != null ? helper : helperMissing),(typeof helper === functionType ? helper.call(depth0, {"name":"pockethost","hash":{},"data":data}) : helper)))
+    + "/ff_signup?s=ffi&tv=panel_control&t=signupff&v="
+    + escapeExpression(((helper = (helper = helpers.variant || (depth0 != null ? depth0.variant : depth0)) != null ? helper : helperMissing),(typeof helper === functionType ? helper.call(depth0, {"name":"variant","hash":{},"data":data}) : helper)))
+    + "\" target=\"_blank\" class=\"btn signup-btn-firefox\"><span class=\"logo\"></span><span class=\"text\">"
+    + escapeExpression(((helper = (helper = helpers.signupfirefox || (depth0 != null ? depth0.signupfirefox : depth0)) != null ? helper : helperMissing),(typeof helper === functionType ? helper.call(depth0, {"name":"signupfirefox","hash":{},"data":data}) : helper)))
+    + "</span></a></p>\n      <p class=\"btn-container\"><a href=\"https://"
+    + escapeExpression(((helper = (helper = helpers.pockethost || (depth0 != null ? depth0.pockethost : depth0)) != null ? helper : helperMissing),(typeof helper === functionType ? helper.call(depth0, {"name":"pockethost","hash":{},"data":data}) : helper)))
+    + "/signup?force=email&tv=panel_control&src=extension&s=ffi&t=signupemail&v="
+    + escapeExpression(((helper = (helper = helpers.variant || (depth0 != null ? depth0.variant : depth0)) != null ? helper : helperMissing),(typeof helper === functionType ? helper.call(depth0, {"name":"variant","hash":{},"data":data}) : helper)))
+    + "\" target=\"_blank\" class=\"btn btn-secondary signup-btn-email signup-btn-initstate\">"
+    + escapeExpression(((helper = (helper = helpers.signupemail || (depth0 != null ? depth0.signupemail : depth0)) != null ? helper : helperMissing),(typeof helper === functionType ? helper.call(depth0, {"name":"signupemail","hash":{},"data":data}) : helper)))
+    + "</a></p>\n     <p class=\"alreadyhave\">"
+    + escapeExpression(((helper = (helper = helpers.alreadyhaveacct || (depth0 != null ? depth0.alreadyhaveacct : depth0)) != null ? helper : helperMissing),(typeof helper === functionType ? helper.call(depth0, {"name":"alreadyhaveacct","hash":{},"data":data}) : helper)))
+    + " <a href=\"https://"
+    + escapeExpression(((helper = (helper = helpers.pockethost || (depth0 != null ? depth0.pockethost : depth0)) != null ? helper : helperMissing),(typeof helper === functionType ? helper.call(depth0, {"name":"pockethost","hash":{},"data":data}) : helper)))
+    + "/login?ep=3&tv=panel_control&src=extension&s=ffi&t=login&v="
+    + escapeExpression(((helper = (helper = helpers.variant || (depth0 != null ? depth0.variant : depth0)) != null ? helper : helperMissing),(typeof helper === functionType ? helper.call(depth0, {"name":"variant","hash":{},"data":data}) : helper)))
+    + "\" target=\"_blank\">"
+    + escapeExpression(((helper = (helper = helpers.loginnow || (depth0 != null ? depth0.loginnow : depth0)) != null ? helper : helperMissing),(typeof helper === functionType ? helper.call(depth0, {"name":"loginnow","hash":{},"data":data}) : helper)))
+    + "</a>.</p>\n";
+},"13":function(depth0,helpers,partials,data) {
+  var stack1, helper, functionType="function", helperMissing=helpers.helperMissing, escapeExpression=this.escapeExpression, buffer = "      <p class=\"btn-container\"><a href=\"https://"
+    + escapeExpression(((helper = (helper = helpers.pockethost || (depth0 != null ? depth0.pockethost : depth0)) != null ? helper : helperMissing),(typeof helper === functionType ? helper.call(depth0, {"name":"pockethost","hash":{},"data":data}) : helper)))
+    + "/firefox_tryitnow?s=ffi&tv=panel_tryit&t=tryitnow\" target=\"_blank\" class=\"btn signup-btn-tryitnow\"><span class=\"text\">"
+    + escapeExpression(((helper = (helper = helpers.tryitnow || (depth0 != null ? depth0.tryitnow : depth0)) != null ? helper : helperMissing),(typeof helper === functionType ? helper.call(depth0, {"name":"tryitnow","hash":{},"data":data}) : helper)))
+    + "</span></a></p>\n      <p class=\"alreadyhave tryitnowspace\">"
+    + escapeExpression(((helper = (helper = helpers.alreadyhaveacct || (depth0 != null ? depth0.alreadyhaveacct : depth0)) != null ? helper : helperMissing),(typeof helper === functionType ? helper.call(depth0, {"name":"alreadyhaveacct","hash":{},"data":data}) : helper)))
+    + " <a href=\"https://"
+    + escapeExpression(((helper = (helper = helpers.pockethost || (depth0 != null ? depth0.pockethost : depth0)) != null ? helper : helperMissing),(typeof helper === functionType ? helper.call(depth0, {"name":"pockethost","hash":{},"data":data}) : helper)))
+    + "/login?ep=3&s=ffi&tv=panel_tryit&src=extension&t=login&v="
+    + escapeExpression(((helper = (helper = helpers.variant || (depth0 != null ? depth0.variant : depth0)) != null ? helper : helperMissing),(typeof helper === functionType ? helper.call(depth0, {"name":"variant","hash":{},"data":data}) : helper)))
+    + "\" target=\"_blank\">"
+    + escapeExpression(((helper = (helper = helpers.loginnow || (depth0 != null ? depth0.loginnow : depth0)) != null ? helper : helperMissing),(typeof helper === functionType ? helper.call(depth0, {"name":"loginnow","hash":{},"data":data}) : helper)))
+    + "</a>.</p>\n      <p class=\"pkt_ext_tos\">";
+  stack1 = ((helper = (helper = helpers.tos || (depth0 != null ? depth0.tos : depth0)) != null ? helper : helperMissing),(typeof helper === functionType ? helper.call(depth0, {"name":"tos","hash":{},"data":data}) : helper));
+  if (stack1 != null) { buffer += stack1; }
+  return buffer + "</p>\n";
+},"compiler":[6,">= 2.0.0-beta.1"],"main":function(depth0,helpers,partials,data) {
+  var stack1, helper, functionType="function", helperMissing=helpers.helperMissing, escapeExpression=this.escapeExpression, buffer = "<div class=\"pkt_ext_introdetail pkt_ext_introdetailstoryboard\">\n <div class=\"pkt_ext_introstory pkt_ext_introstoryone\">\n    <div class=\"pkt_ext_introstory_text\">\n     <p class=\"pkt_ext_tagline\">"
+    + escapeExpression(((helper = (helper = helpers.taglinestory_one || (depth0 != null ? depth0.taglinestory_one : depth0)) != null ? helper : helperMissing),(typeof helper === functionType ? helper.call(depth0, {"name":"taglinestory_one","hash":{},"data":data}) : helper)))
+    + "</p>\n   </div>\n    <div class=\"pkt_ext_introstoryone_img\"></div>\n </div>\n  <div class=\"pkt_ext_introstorydivider\"></div>\n <div class=\"pkt_ext_introstory pkt_ext_introstorytwo\">\n    <div class=\"pkt_ext_introstory_text\">\n     <p class=\"pkt_ext_tagline\">"
+    + escapeExpression(((helper = (helper = helpers.taglinestory_two || (depth0 != null ? depth0.taglinestory_two : depth0)) != null ? helper : helperMissing),(typeof helper === functionType ? helper.call(depth0, {"name":"taglinestory_two","hash":{},"data":data}) : helper)))
+    + "</p>\n";
+  stack1 = helpers['if'].call(depth0, (depth0 != null ? depth0.showlearnmore : depth0), {"name":"if","hash":{},"fn":this.program(1, data),"inverse":this.program(6, data),"data":data});
+  if (stack1 != null) { buffer += stack1; }
+  buffer += "   </div>\n    <div class=\"pkt_ext_introstorytwo_img\"></div>\n </div>\n</div>\n<div class=\"pkt_ext_signupdetail\">\n";
+  stack1 = helpers['if'].call(depth0, (depth0 != null ? depth0.fxasignedin : depth0), {"name":"if","hash":{},"fn":this.program(8, data),"inverse":this.program(10, data),"data":data});
+  if (stack1 != null) { buffer += stack1; }
+  return buffer + "\n</div>\n";
+},"useData":true});
 })();

--- a/content/panels/tmpl/signup_shell.handlebars
+++ b/content/panels/tmpl/signup_shell.handlebars
@@ -2,19 +2,31 @@
 	<h2 class="pkt_ext_logo">Pocket</h2>
 	<p class="pkt_ext_tagline">{{tagline}}</p>
 	{{#if showlearnmore}}
-	<p class="pkt_ext_learnmorecontainer"><a class="pkt_ext_learnmore" href="https://{{pockethost}}?s=ffi&t=learnmore&v={{variant}}" target="_blank">{{learnmore}}</a></p>
+		{{#if controlvariant}}
+			<p class="pkt_ext_learnmorecontainer"><a class="pkt_ext_learnmore" href="https://{{pockethost}}/firefox_learnmore?s=ffi&t=learnmore&tv=panel_control&v={{variant}}" target="_blank">{{learnmore}}</a></p>
+		{{else}}
+			<p class="pkt_ext_learnmorecontainer"><a class="pkt_ext_learnmore" href="https://{{pockethost}}/firefox_learnmore?s=ffi&t=learnmore&tv=panel_tryit&v={{variant}}" target="_blank">{{learnmore}}</a></p>
+		{{/if}}
 	{{else}}
 	<p class="pkt_ext_learnmorecontainer"><a class="pkt_ext_learnmore pkt_ext_learnmoreinactive" href="#">{{learnmore}}</a></p>
 	{{/if}}
 	<div class="pkt_ext_introimg"></div>
 </div>
 <div class="pkt_ext_signupdetail pkt_ext_signupdetail_hero">
-	<h4>{{signuptosave}}</h4>
 	{{#if fxasignedin}}
+	<h4>{{signuptosave}}</h4>
 	<p class="btn-container"><a href="https://{{pockethost}}/ff_signup?s=ffi&t=signupff&v={{variant}}" target="_blank" class="btn signup-btn-firefox"><span class="logo"></span><span class="text">{{signinfirefox}}</span></a></p>
-	{{else}}
-	<p class="btn-container"><a href="https://{{pockethost}}/ff_signup?s=ffi&t=signupff&v={{variant}}" target="_blank" class="btn signup-btn-firefox"><span class="logo"></span><span class="text">{{signupfirefox}}</span></a></p>
-	<p class="btn-container"><a href="https://{{pockethost}}/signup?force=email&src=extension&s=ffi&t=signupemail&v={{variant}}" target="_blank" class="btn btn-secondary signup-btn-email signup-btn-initstate">{{signupemail}}</a></p>
-	{{/if}}
 	<p class="alreadyhave">{{alreadyhaveacct}} <a href="https://{{pockethost}}/login?ep=3&src=extension&s=ffi&t=login&v={{variant}}" target="_blank">{{loginnow}}</a>.</p>
+	{{else}}
+		{{#if controlvariant}}
+			<h4>{{signuptosave}}</h4>
+			<p class="btn-container"><a href="https://{{pockethost}}/ff_signup?s=ffi&tv=panel_control&t=signupff&v={{variant}}" target="_blank" class="btn signup-btn-firefox"><span class="logo"></span><span class="text">{{signupfirefox}}</span></a></p>
+			<p class="btn-container"><a href="https://{{pockethost}}/signup?force=email&tv=panel_control&src=extension&s=ffi&t=signupemail&v={{variant}}" target="_blank" class="btn btn-secondary signup-btn-email signup-btn-initstate">{{signupemail}}</a></p>
+			<p class="alreadyhave">{{alreadyhaveacct}} <a href="https://{{pockethost}}/login?ep=3&tv=panel_control&src=extension&s=ffi&t=login&v={{variant}}" target="_blank">{{loginnow}}</a>.</p>
+		{{else}}
+			<p class="btn-container"><a href="https://{{pockethost}}/firefox_tryitnow?s=ffi&tv=panel_tryit&t=tryitnow" target="_blank" class="btn signup-btn-tryitnow"><span class="text">{{tryitnow}}</span></a></p>
+			<p class="alreadyhave tryitnowspace">{{alreadyhaveacct}} <a href="https://{{pockethost}}/login?ep=3&s=ffi&tv=panel_tryit&src=extension&t=login&v={{variant}}" target="_blank">{{loginnow}}</a>.</p>
+			<p class="pkt_ext_tos">{{{tos}}}</p>
+		{{/if}}
+	{{/if}}
 </div>

--- a/content/panels/tmpl/signupstoryboard_shell.handlebars
+++ b/content/panels/tmpl/signupstoryboard_shell.handlebars
@@ -10,7 +10,11 @@
 		<div class="pkt_ext_introstory_text">
 			<p class="pkt_ext_tagline">{{taglinestory_two}}</p>
 			{{#if showlearnmore}}
-			<p><a class="pkt_ext_learnmore" href="https://{{pockethost}}?s=ffi&t=learnmore&v={{variant}}" target="_blank">{{learnmore}}</a></p>
+				{{#if controlvariant}}
+					<p><a class="pkt_ext_learnmore" href="https://{{pockethost}}/firefox_learnmore?s=ffi&t=learnmore&tv=panel_control&v={{variant}}" target="_blank">{{learnmore}}</a></p>
+				{{else}}
+					<p><a class="pkt_ext_learnmore" href="https://{{pockethost}}/firefox_learnmore?s=ffi&t=learnmore&tv=panel_tryit&v={{variant}}" target="_blank">{{learnmore}}</a></p>
+				{{/if}}
 			{{else}}
 			<p><a class="pkt_ext_learnmore pkt_ext_learnmoreinactive" href="#">{{learnmore}}</a></p>
 			{{/if}}
@@ -19,12 +23,21 @@
 	</div>
 </div>
 <div class="pkt_ext_signupdetail">
-	<h4>{{signuptosave}}</h4>
 	{{#if fxasignedin}}
+	<h4>{{signuptosave}}</h4>
 	<p class="btn-container"><a href="https://{{pockethost}}/ff_signup?s=ffi&t=signupff&v={{variant}}" target="_blank" class="btn signup-btn-firefox"><span class="logo"></span><span class="text">{{signinfirefox}}</span></a></p>
-	{{else}}
-	<p class="btn-container"><a href="https://{{pockethost}}/ff_signup?s=ffi&t=signupff&v={{variant}}" target="_blank" class="btn signup-btn-firefox"><span class="logo"></span><span class="text">{{signupfirefox}}</span></a></p>
-	<p class="btn-container"><a href="https://{{pockethost}}/signup?force=email&src=extension&s=ffi&t=signupemail&v={{variant}}" target="_blank" class="btn btn-secondary signup-btn-email signup-btn-initstate">{{signupemail}}</a></p>
-	{{/if}}
 	<p class="alreadyhave">{{alreadyhaveacct}} <a href="https://{{pockethost}}/login?ep=3&src=extension&s=ffi&t=login&v={{variant}}" target="_blank">{{loginnow}}</a>.</p>
+	{{else}}
+		{{#if controlvariant}}
+			<h4>{{signuptosave}}</h4>
+			<p class="btn-container"><a href="https://{{pockethost}}/ff_signup?s=ffi&tv=panel_control&t=signupff&v={{variant}}" target="_blank" class="btn signup-btn-firefox"><span class="logo"></span><span class="text">{{signupfirefox}}</span></a></p>
+			<p class="btn-container"><a href="https://{{pockethost}}/signup?force=email&tv=panel_control&src=extension&s=ffi&t=signupemail&v={{variant}}" target="_blank" class="btn btn-secondary signup-btn-email signup-btn-initstate">{{signupemail}}</a></p>
+			<p class="alreadyhave">{{alreadyhaveacct}} <a href="https://{{pockethost}}/login?ep=3&tv=panel_control&src=extension&s=ffi&t=login&v={{variant}}" target="_blank">{{loginnow}}</a>.</p>
+		{{else}}
+			<p class="btn-container"><a href="https://{{pockethost}}/firefox_tryitnow?s=ffi&tv=panel_tryit&t=tryitnow" target="_blank" class="btn signup-btn-tryitnow"><span class="text">{{tryitnow}}</span></a></p>
+			<p class="alreadyhave tryitnowspace">{{alreadyhaveacct}} <a href="https://{{pockethost}}/login?ep=3&s=ffi&tv=panel_tryit&src=extension&t=login&v={{variant}}" target="_blank">{{loginnow}}</a>.</p>
+			<p class="pkt_ext_tos">{{{tos}}}</p>
+		{{/if}}
+	{{/if}}
+
 </div>

--- a/content/pktApi.jsm
+++ b/content/pktApi.jsm
@@ -625,13 +625,13 @@ var pktApi = (function() {
             // Get a weighted array of test variants from the testOptions object
             Object.keys(testOptions).forEach(function(key) {
               for (var i = 0; i < testOptions[key]; i++) {
-                valArray.push(key)
+                valArray.push(key);
               }
             });
 
             // Get a random test variant and set the user to it
-            assignedValue = valArray[Math.floor(Math.random() * valArray.length)]
-            setSetting(settingName, assignedValue)
+            assignedValue = valArray[Math.floor(Math.random() * valArray.length)];
+            setSetting(settingName, assignedValue);
         }
 
         return assignedValue;

--- a/content/pktApi.jsm
+++ b/content/pktApi.jsm
@@ -610,7 +610,7 @@ var pktApi = (function() {
      * Helper function to get current signup AB group the user is in
      */
     function getSignupPanelTabTestVariant() {
-        return getSimpleTestOption('panelTab', 0.1, 'tab');
+        return getMultipleTestOption('panelSignUp', {control: 2, v1: 7, v2: 1 })
     }
 
     function getSimpleTestOption(testName, threshold, testOptionName) {
@@ -634,6 +634,30 @@ var pktApi = (function() {
         return assignedValue;
     }
 
+    function getMultipleTestOption(testName, testOptions) {
+        // Get the test from preferences if we've already assigned the user to a test
+        var settingName = 'test.' + testName;
+        var assignedValue = getSetting(settingName);
+        var valArray = [];
+
+        // If not assigned yet, pick and store a value
+        if (!assignedValue)
+        {
+            // Get a weighted array of test variants from the testOptions object
+            Object.keys(testOptions).forEach(function(key) {
+              for (var i = 0; i < testOptions[key]; i++) {
+                valArray.push(key)
+              }
+            });
+
+            // Get a random test variant and set the user to it
+            assignedValue = valArray[Math.floor(Math.random() * valArray.length)]
+            setSetting(settingName, assignedValue)
+        }
+
+        return assignedValue;
+
+    }
 
     /**
      * Public functions

--- a/content/pktApi.jsm
+++ b/content/pktApi.jsm
@@ -613,27 +613,6 @@ var pktApi = (function() {
         return getMultipleTestOption('panelSignUp', {control: 2, v1: 7, v2: 1 })
     }
 
-    function getSimpleTestOption(testName, threshold, testOptionName) {
-        // Get the test from preferences if we've already assigned the user to a test
-        var settingName = 'test.' + testName;
-        var assignedValue = getSetting(settingName);
-
-        // If not assigned yet, pick and store a value
-        if (!assignedValue)
-        {
-            if (Math.random() <= threshold) {
-                assignedValue = testOptionName;
-            }
-            else {
-                assignedValue = 'control';
-            }
-
-            setSetting('test.'+testName, assignedValue);
-        }
-
-        return assignedValue;
-    }
-
     function getMultipleTestOption(testName, testOptions) {
         // Get the test from preferences if we've already assigned the user to a test
         var settingName = 'test.' + testName;

--- a/locale/en-US/pocket.properties
+++ b/locale/en-US/pocket.properties
@@ -26,7 +26,7 @@ tagline = Save articles and videos from Firefox to view in Pocket on any device,
 taglinestory_one = Click the Pocket Button to save any article, video or page from Firefox.
 taglinestory_two = View in Pocket on any device, any time.
 tagssaved = Tags Added
-tos = By continuing, you agree to Pocket's <a href="[tos_link]" target="_blank">Terms of Service</a> and <a href="[privacy_link]" target="_blank">Privacy Policy</a>
+tos = By continuing, you agree to Pocket's <a href="%1$S" target="_blank">Terms of Service</a> and <a href="%2$S" target="_blank">Privacy Policy</a>
 tryitnow = Try It Now
 signinfirefox = Sign in with Firefox
 signupfirefox = Sign up with Firefox

--- a/locale/en-US/pocket.properties
+++ b/locale/en-US/pocket.properties
@@ -26,7 +26,7 @@ tagline = Save articles and videos from Firefox to view in Pocket on any device,
 taglinestory_one = Click the Pocket Button to save any article, video or page from Firefox.
 taglinestory_two = View in Pocket on any device, any time.
 tagssaved = Tags Added
-tos = By continuing, you agree to Pocket's <a href="*" target="_blank">Terms of Service</a> and <a href="*" target="_blank">Privacy Policy</a>
+tos = By continuing, you agree to Pocket's <a href="[tos_link]" target="_blank">Terms of Service</a> and <a href="[privacy_link]" target="_blank">Privacy Policy</a>
 tryitnow = Try It Now
 signinfirefox = Sign in with Firefox
 signupfirefox = Sign up with Firefox

--- a/locale/en-US/pocket.properties
+++ b/locale/en-US/pocket.properties
@@ -26,6 +26,8 @@ tagline = Save articles and videos from Firefox to view in Pocket on any device,
 taglinestory_one = Click the Pocket Button to save any article, video or page from Firefox.
 taglinestory_two = View in Pocket on any device, any time.
 tagssaved = Tags Added
+tos = By continuing, you agree to Pocket's <a href="*" target="_blank">Terms of Service</a> and <a href="*" target="_blank">Privacy Policy</a>
+tryitnow = Try It Now
 signinfirefox = Sign in with Firefox
 signupfirefox = Sign up with Firefox
 viewlist = View List


### PR DESCRIPTION
**Background**
With the current version of the add-on, we are sending 10% of logged out users that clicked on the pocket add-on button directly to our "Learn More" page (https://getpocket.com/firefox_learnmore). On that "Learn More" page, we tested a version of the call to action that allowed users to use Pocket without having to signup for an account with a single "Try it Now" button. We found that this version converted users nearly twice as much when compared with the traditional signup / login call to action. Later in the experience users are encouraged to add their email/password if they want to use additional functionality such as use the mobile apps or share saved content with friends.

Additionally, we found that people converted, again, almost twice as much from the panel that pops-up after clicking on the add-on button while being logged-out, compared to when we sent them to that "Learn More" page with the same signup / login options.

**Updates to the Add-on**
Given these findings, we’ve moved this new ability for users to use Pocket without an account e.g. the "Try it Now” button, directly into the panel that pops-up when logged-out users click on the add-on button. This will reduce friction, allow 3-4x more users to benefit from the add-on, and make the Pocket integration feel more native to Firefox.

This new version makes the new Try It option the default, but in order to confirm the results hold true in the panel version, we still have a small test cohort using the “old” sign-up first version. The 3 variants are:

1. Show the traditional login/signup panel for 20% of logged-out users that click on the add-on button.
2. Show the panel that allows users to use Pocket without an account ("Try it Now" version) to 70% of logged-out users that click on the add-on button.
3. Continue to send 10% of people directly to the "Learn More" page after clicking on the button.

**Testing**
You can test the 3 variations by logging out of Pocket, then changing the “extensions.pocket.settings.test.panelSignUp” setting in about:config to one of the following values:

- “control” = old sign-up panel
- “v1” = new try it now panel
- “v2” = opens to learn more tab
