### PR TITLE
Fixing Misnamed Test Variable

### DIFF
--- a/content/main.js
+++ b/content/main.js
@@ -129,7 +129,7 @@ var pktUI = (function() {
      */
     function showSignUp() {
         // AB test: Direct logged-out users to tab vs panel
-        if (pktApi.getSignupPanelTabTestVariant() == 'tab')
+        if (pktApi.getSignupPanelTabTestVariant() == 'v2')
         {
             let site = Services.prefs.getCharPref("extensions.pocket.site");
             openTabWithUrl('https://' + site + '/firefox_learnmore?s=ffi&t=autoredirect&tv=page_learnmore&src=ff_ext', true);


### PR DESCRIPTION
When running some tests against the nightly we found that this fraction of the test wasn't behaving as expected.  Tracked it down to this misnamed condition left over from the prior test.  @mixedpuppy @ideashower 