### PR TITLE
Adjusting test weights for signup panels

### DIFF
--- a/content/pktApi.jsm
+++ b/content/pktApi.jsm
@@ -610,7 +610,7 @@ var pktApi = (function() {
      * Helper function to get current signup AB group the user is in
      */
     function getSignupPanelTabTestVariant() {
-        return getMultipleTestOption('panelSignUp', {control: 2, v1: 7, v2: 1 })
+        return getMultipleTestOption('panelSignUp', {control: 1, v1: 2, v2: 7 })
     }
 
     function getMultipleTestOption(testName, testOptions) {


### PR DESCRIPTION
Updated the weights on the test variants for a scenario that converts Firefox users better than before and provides more immediate value.

- Control panel (Control): 10%
- “Try it Now” panel (Variation 1): 20%
- New Tab (Variation 2): 70%

